### PR TITLE
Fix container item duplication and Il2CppInterop warnings

### DIFF
--- a/VisualStudio/src/Components/CarryableComponent.cs
+++ b/VisualStudio/src/Components/CarryableComponent.cs
@@ -27,7 +27,7 @@
             CarryableManager.Remove(this);
         }
 
-        public CarryableSaveDataProxy ToProxy(bool shorten = false)
+        internal CarryableSaveDataProxy ToProxy(bool shorten = false)
         {
             CS state = GetState();
             string data = "";
@@ -104,7 +104,7 @@
             return proxy;
         }
 
-        public void FromProxy(CarryableSaveDataProxy proxy, bool full, bool ignoreAdditionalData = false, bool ignorePosition = false)
+        internal void FromProxy(CarryableSaveDataProxy proxy, bool full, bool ignoreAdditionalData = false, bool ignorePosition = false)
         {
             this.objectName = proxy.name;
             this.type = proxy.type;
@@ -246,7 +246,12 @@
                     Container[] containersAW = this.GetComponentsInChildren<Container>();
                     for (int ii = 0; ii < containersAW.Count(); ii++)
                     {
-                        if (splitData.Length > ii) containersAW[ii].Deserialize(DecompressDeflate(splitData[ii + 1]), null);
+                        if (splitData.Length > ii)
+                        {
+                            // Clear existing decoration items to prevent duplication
+                            containersAW[ii].m_DecorationItems.Clear();
+                            containersAW[ii].Deserialize(DecompressDeflate(splitData[ii + 1]), null);
+                        }
                     }
                     break;
                 case CT.Container:
@@ -254,7 +259,12 @@
                     Container[] containers = this.GetComponentsInChildren<Container>();
                     for (int ii = 0; ii < containers.Count(); ii++)
                     {
-                        if (splitData.Length > ii) containers[ii].Deserialize(DecompressDeflate(splitData[ii]), null);
+                        if (splitData.Length > ii)
+                        {
+                            // Clear existing decoration items to prevent duplication
+                            containers[ii].m_DecorationItems.Clear();
+                            containers[ii].Deserialize(DecompressDeflate(splitData[ii]), null);
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
This commit fixes two related bugs that caused ID cards and other decoration items to duplicate when both SafehouseCustomizationPlus and PlacingAnywhere mods are loaded together.

**Issue 1: Il2CppInterop warnings**
The ToProxy() and FromProxy() methods on SCPlusCarryable were marked as public, causing Il2CppInterop to attempt exposing them to the Il2Cpp domain. However, these methods use CarryableSaveDataProxy as a parameter/return type, which is not an Il2Cpp-compatible type. This caused warnings during mod loading:
  "Method ToProxy has unsupported return type CarryableSaveDataProxy"
  "Method FromProxy has unsupported parameter CarryableSaveDataProxy"

**Solution:** Changed ToProxy() and FromProxy() from public to internal, since they are only called from managed C# code within the mod.

**Issue 2: Container item duplication**
In RetrieveAdditionalData(), when deserializing Container and AmmoWorkbench types, the code called Container.Deserialize() without first clearing existing items. When containers were instantiated from assets, they often contained default items (like ID cards). The deserialization process would then ADD saved items on top of existing ones, causing duplication on each scene reload.

**Solution:** Clear m_DecorationItems before calling Deserialize() to ensure a clean slate before loading saved items.

**Testing:** This fix resolves the issue where ID cards would appear and multiply on the floor when using both SafehouseCustomizationPlus and PlacingAnywhere mods together.

Fixes compatibility issue with PlacingAnywhere mod v2.8.0